### PR TITLE
Fix Selenium not starting.

### DIFF
--- a/headless-selenium
+++ b/headless-selenium
@@ -132,7 +132,7 @@ case "${1:-''}" in
     fi
 
  # If we come out of the loop with 2... there's a problem.
-    if [[ $num -eq 2 || $num -eq 3 ]]
+    if [[ $num -eq 2 || $num -eq 1 ]]
     then
       echo "${bon}Error $error! Couldn't start Selenium!${boff}"
       sleep 1


### PR DESCRIPTION
Thanks for this great script.
This error seems to show up when starting the service:

```
[user@workstation ~]$ /etc/init.d/headless-selenium start
Starting Xvfb...
Starting Selenium.
Error 0! Couldn't start Selenium!
Stopping Headless Selenium...
```

On my machine, at line 137 I have $num = 3 which does not seem to indicate that there is a problem.
Here is an attempt to fix the issue. Does it make sense ?
